### PR TITLE
Fix notification after adding new product

### DIFF
--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/SampleCrudLogic.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/SampleCrudLogic.java
@@ -76,11 +76,15 @@ public class SampleCrudLogic implements Serializable {
     }
 
     public void saveProduct(Product product) {
-        view.showSaveNotification(product.getProductName() + " ("
-                + product.getId() + ") updated");
+        boolean newProduct = product.isNewProduct();
+
         view.clearSelection();
         view.updateProduct(product);
         setFragmentParameter("");
+
+        view.showSaveNotification(
+                product.getProductName() + " (" + product.getId() + ") "
+                        + (newProduct ? "created" : "updated"));
     }
 
     public void deleteProduct(Product product) {


### PR DESCRIPTION
After adding a new product, the notification shows
- "created" instead of "updated"
- the id which was assigned instead of -1

Fixes #37