### PR TITLE
Update vaadin version back to 12.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>bookstore-starter-flow-parent</name>
 
     <properties>
-        <vaadin.version>12.0.1</vaadin.version>
+        <vaadin.version>12.0.0</vaadin.version>
         <jetty.plugin.version>9.4.11.v20180605</jetty.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8


### PR DESCRIPTION
Because of a known bug in `vaadin-context-menu-flow 1.2.1` which is part of `vaadin 12.0.1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bookstore-starter-flow/82)
<!-- Reviewable:end -->
