### PR TITLE
Issues/4870 keyboard shortcuts

### DIFF
--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/MainLayout.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/MainLayout.java
@@ -1,5 +1,8 @@
 package com.vaadin.samples;
 
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
@@ -8,6 +11,7 @@ import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
 import com.vaadin.samples.about.AboutView;
+import com.vaadin.samples.authentication.AccessControlFactory;
 import com.vaadin.samples.crud.SampleCrudView;
 
 /**
@@ -30,5 +34,10 @@ public class MainLayout extends FlexLayout implements RouterLayout {
                 VaadinIcon.INFO_CIRCLE.create());
 
         add(menu);
+
+        UI.getCurrent().addShortcut(
+                () -> AccessControlFactory.getInstance().createAccessControl()
+                        .signOut(),
+                Key.KEY_L, KeyModifier.CONTROL);
     }
 }

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/Menu.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/Menu.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.samples.authentication.AccessControlFactory;
 
 public class Menu extends FlexLayout {
 
@@ -65,10 +66,8 @@ public class Menu extends FlexLayout {
         // logout menu item
         Button logoutButton = new Button("Logout",
                 VaadinIcon.SIGN_OUT.create());
-        logoutButton.addClickListener(event -> {
-            VaadinSession.getCurrent().getSession().invalidate();
-            UI.getCurrent().getPage().reload();
-        });
+        logoutButton.addClickListener(event -> AccessControlFactory
+                .getInstance().createAccessControl().signOut());
 
         logoutButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
         add(logoutButton);

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/AccessControl.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/AccessControl.java
@@ -10,11 +10,13 @@ public interface AccessControl extends Serializable {
     String ADMIN_ROLE_NAME = "admin";
     String ADMIN_USERNAME = "admin";
 
-    public boolean signIn(String username, String password);
+    boolean signIn(String username, String password);
 
-    public boolean isUserSignedIn();
+    boolean isUserSignedIn();
 
-    public boolean isUserInRole(String role);
+    boolean isUserInRole(String role);
 
-    public String getPrincipalName();
+    String getPrincipalName();
+
+    void signOut();
 }

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/BasicAccessControl.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/BasicAccessControl.java
@@ -1,5 +1,8 @@
 package com.vaadin.samples.authentication;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinSession;
+
 /**
  * Default mock implementation of {@link AccessControl}. This implementation
  * accepts any string as a password, and considers the user "admin" as the only
@@ -37,4 +40,9 @@ public class BasicAccessControl implements AccessControl {
         return CurrentUser.get();
     }
 
+    @Override
+    public void signOut() {
+        VaadinSession.getCurrent().getSession().invalidate();
+        UI.getCurrent().getPage().reload();
+    }
 }

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/LoginScreen.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/authentication/LoginScreen.java
@@ -2,6 +2,8 @@ package com.vaadin.samples.authentication;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Shortcuts;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -67,9 +69,13 @@ public class LoginScreen extends FlexLayout {
         loginForm.addFormItem(username = new TextField(), "Username");
         username.setWidth("15em");
         username.setValue("admin");
+        Shortcuts.addShortcut(username, username, () -> password.focus(),
+                Key.ENTER);
+
         loginForm.add(new Html("<br/>"));
         loginForm.addFormItem(password = new PasswordField(), "Password");
         password.setWidth("15em");
+        Shortcuts.addShortcut(password, password, this::login, Key.ENTER);
 
         HorizontalLayout buttons = new HorizontalLayout();
         loginForm.add(new Html("<br/>"));
@@ -77,7 +83,6 @@ public class LoginScreen extends FlexLayout {
 
         buttons.add(login = new Button("Login"));
         login.addClickListener(event -> login());
-        loginForm.getElement().addEventListener("keypress", event -> login()).setFilter("event.key == 'Enter'");
         login.addThemeVariants(ButtonVariant.LUMO_SUCCESS, ButtonVariant.LUMO_PRIMARY);
 
         buttons.add(forgotPassword = new Button("Forgot password?"));

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/ProductForm.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/ProductForm.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
@@ -158,6 +160,7 @@ public class ProductForm extends Div {
                 viewLogic.saveProduct(currentProduct);
             }
         });
+        save.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL);
 
         discard = new Button("Discard changes");
         discard.setWidth("100%");
@@ -167,6 +170,7 @@ public class ProductForm extends Div {
         cancel = new Button("Cancel");
         cancel.setWidth("100%");
         cancel.addClickListener(event -> viewLogic.cancelProduct());
+        cancel.addClickShortcut(Key.ESCAPE);
         getElement()
                 .addEventListener("keydown", event -> viewLogic.cancelProduct())
                 .setFilter("event.key == 'Escape'");

--- a/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/SampleCrudView.java
+++ b/bookstore-starter-flow-ui/src/main/java/com/vaadin/samples/crud/SampleCrudView.java
@@ -1,5 +1,7 @@
 package com.vaadin.samples.crud;
 
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -68,11 +70,14 @@ public class SampleCrudView extends HorizontalLayout
         filter.setPlaceholder("Filter name, availability or category");
         // Apply the filter to grid's data provider. TextField value is never null
         filter.addValueChangeListener(event -> dataProvider.setFilter(event.getValue()));
+        filter.addFocusShortcut(Key.KEY_F, KeyModifier.CONTROL);
 
         newProduct = new Button("New product");
         newProduct.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         newProduct.setIcon(VaadinIcon.PLUS_CIRCLE.create());
         newProduct.addClickListener(click -> viewLogic.newProduct());
+        // CTRL+N will create a new window which is unavoidable
+        newProduct.addClickShortcut(Key.KEY_N, KeyModifier.ALT);
 
         HorizontalLayout topLayout = new HorizontalLayout();
         topLayout.setWidth("100%");


### PR DESCRIPTION
**Features:**
- adds `signOut()` method to `AccessControl`, provides implementation, and takes it into use
- adds keyboard shortcuts
  - `CTRL+L` logs out the user
  - `CTRL+F` moves focus to "filter" field
  - `ALT+N` open product form
  - When product form is open:
    - `Escape` closes the form
    - `CTRL+S` saves the product
  - When in login page:
    - In "username" field, `Enter` moved focus to "password" field
    - In "password" field, `Enter` tries to log in

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bookstore-starter-flow/89)
<!-- Reviewable:end -->
